### PR TITLE
timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oapi"
-version = "2.8.3"
+version = "2.8.5"
 description = "A library for generating web API clients from OpenAPI documents"
 readme = "README.md"
 license = "MIT"

--- a/src/oapi/client.py
+++ b/src/oapi/client.py
@@ -1551,7 +1551,11 @@ class Client:
                         urlencode(data_dict),
                         encoding="ascii",
                     ),
-                )
+                ),
+                timeout=self.timeout
+                or inspect.signature(OpenerDirector.open)
+                .parameters["timeout"]
+                .default,
             )
         except HTTPError as error:
             location: str = error.headers.get(
@@ -1582,10 +1586,17 @@ class Client:
                     )
                 )
                 oidc_configuration: dict[str, typing.Any] = json.load(
-                    urlopen(url)  # noqa: S310
+                    urlopen(url, timeout=self.timeout)  # noqa: S310
                 )
-            except HTTPError:
-                pass
+            except URLError as error:
+                if not isinstance(error, HTTPError) and (
+                    "timed out" in sob.errors.get_exception_text()
+                ):
+                    message: str = (
+                        "Failed to retrieve OpenID Connect configuration "
+                        f"from {url!r}."
+                    )
+                    raise TimeoutError(message) from error
             else:
                 # Store the token endpoint URL to avoid re-requesting it
                 # after the client has been pickled/unpickled, or caches
@@ -1628,7 +1639,10 @@ class Client:
                 ),
             )
             self._request_callback(request)
-            return self._opener.open(request)  # type: ignore
+            return self._opener.open(
+                request,
+                timeout=self.timeout,
+            )  # type: ignore
         except HTTPError as error:
             location: str | None = error.headers.get(
                 "Location", self.oauth2_token_url


### PR DESCRIPTION
This pull request introduces improvements to OAuth2 authentication handling, focusing on better timeout management and error handling for HTTP requests in the `oapi` library. The changes ensure that timeouts are consistently applied to network requests and that timeout errors are handled more explicitly, improving reliability when interacting with OAuth2 endpoints.

**OAuth2 Timeout Handling and Error Management:**

* Consistently applies the `timeout` parameter to all relevant HTTP requests in OAuth2 authentication flows, including password and client credentials grants, as well as OpenID Connect configuration retrieval (`src/oapi/client.py`). [[1]](diffhunk://#diff-278bae21a0cc2b672683bc4a39f3047f7ffdad91bddc1391edd1574f60a4eb67L1554-R1558) [[2]](diffhunk://#diff-278bae21a0cc2b672683bc4a39f3047f7ffdad91bddc1391edd1574f60a4eb67L1585-R1599) [[3]](diffhunk://#diff-278bae21a0cc2b672683bc4a39f3047f7ffdad91bddc1391edd1574f60a4eb67L1631-R1645)
* Adds explicit handling for timeout errors when retrieving OpenID Connect configuration, raising a `TimeoutError` with a clear message if the request times out (`src/oapi/client.py`).

**Version Update:**

* Bumps the package version from `2.8.3` to `2.8.5` in `pyproject.toml`.